### PR TITLE
PMM-1640: rds exporter simplify config

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -2,12 +2,19 @@ package main
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	PeriodSeconds = 60
+	DelaySeconds  = 600
+	RangeSeconds  = 600
 )
 
 func getLatestDatapoint(datapoints []*cloudwatch.Datapoint) *cloudwatch.Datapoint {
@@ -22,95 +29,70 @@ func getLatestDatapoint(datapoints []*cloudwatch.Datapoint) *cloudwatch.Datapoin
 	return latest
 }
 
-// scrape makes the required calls to AWS CloudWatch by using the parameters in the cwCollector
+// scrape makes the required calls to AWS CloudWatch by using the parameters in the Collector
 // Once converted into Prometheus format, the metrics are pushed on the ch channel.
-func scrape(collector *cwCollector, ch chan<- prometheus.Metric) {
+func scrape(instance, region string, collector *Collector, ch chan<- prometheus.Metric) {
 	session := session.Must(session.NewSession(&aws.Config{
-		Region: aws.String(collector.Region),
+		Region: aws.String(region),
 	}))
 
 	svc := cloudwatch.New(session)
 
-	for m := range collector.Template.Metrics {
-		metric := &collector.Template.Metrics[m]
+	labels := []string{}
+	labels = append(labels, instance, region)
 
-		now := time.Now()
-		end := now.Add(time.Duration(-metric.ConfMetric.DelaySeconds) * time.Second)
-
-		params := &cloudwatch.GetMetricStatisticsInput{
-			EndTime:   aws.Time(end),
-			StartTime: aws.Time(end.Add(time.Duration(-metric.ConfMetric.RangeSeconds) * time.Second)),
-
-			Period:     aws.Int64(int64(metric.ConfMetric.PeriodSeconds)),
-			MetricName: aws.String(metric.ConfMetric.Name),
-			Namespace:  aws.String(metric.ConfMetric.Namespace),
-			Dimensions: []*cloudwatch.Dimension{},
-			Statistics: []*string{},
-			Unit:       nil,
-		}
-
-		for _, stat := range metric.ConfMetric.Statistics {
-			params.Statistics = append(params.Statistics, aws.String(stat))
-		}
-
-		labels := make([]string, 0, len(metric.LabelNames))
-
-		// Loop through the dimensions selects to build the filters and the labels array
-		for dim := range metric.ConfMetric.DimensionsSelect {
-			for val := range metric.ConfMetric.DimensionsSelect[dim] {
-				dimValue := metric.ConfMetric.DimensionsSelect[dim][val]
-
-				// Replace $_target token by the actual URL target
-				if dimValue == "$_target" {
-					dimValue = collector.Target
-				}
-
-				params.Dimensions = append(params.Dimensions, &cloudwatch.Dimension{
-					Name:  aws.String(dim),
-					Value: aws.String(dimValue),
-				})
-
-				labels = append(labels, dimValue)
+	wg := &sync.WaitGroup{}
+	wg.Add(len(collector.Metrics))
+	for _, metric := range collector.Metrics {
+		go func(metric Metric) {
+			err := scrapeMetric(svc, metric, instance, collector, ch, labels)
+			if err != nil {
+				fmt.Println(err)
 			}
-		}
-
-		labels = append(labels, collector.Template.Task.Name)
-
-		// Call CloudWatch to gather the datapoints
-		resp, err := svc.GetMetricStatistics(params)
-		totalRequests.Inc()
-
-		if err != nil {
-			collector.ErroneousRequests.Inc()
-			fmt.Println(err)
-			continue
-		}
-
-		// There's nothing in there, don't publish the metric
-		if len(resp.Datapoints) == 0 {
-			continue
-		}
-
-		// Pick the latest datapoint
-		dp := getLatestDatapoint(resp.Datapoints)
-		if dp.Sum != nil {
-			ch <- prometheus.MustNewConstMetric(metric.Desc, metric.ValType, float64(*dp.Sum), labels...)
-		}
-
-		if dp.Average != nil {
-			ch <- prometheus.MustNewConstMetric(metric.Desc, metric.ValType, float64(*dp.Average), labels...)
-		}
-
-		if dp.Maximum != nil {
-			ch <- prometheus.MustNewConstMetric(metric.Desc, metric.ValType, float64(*dp.Maximum), labels...)
-		}
-
-		if dp.Minimum != nil {
-			ch <- prometheus.MustNewConstMetric(metric.Desc, metric.ValType, float64(*dp.Minimum), labels...)
-		}
-
-		if dp.SampleCount != nil {
-			ch <- prometheus.MustNewConstMetric(metric.Desc, metric.ValType, float64(*dp.SampleCount), labels...)
-		}
+			wg.Done()
+		}(metric)
 	}
+	wg.Wait()
+}
+
+func scrapeMetric(svc *cloudwatch.CloudWatch, metric Metric, instance string, collector *Collector, ch chan<- prometheus.Metric, labels []string) error {
+	now := time.Now()
+	end := now.Add(time.Duration(-DelaySeconds) * time.Second)
+
+	params := &cloudwatch.GetMetricStatisticsInput{
+		EndTime:   aws.Time(end),
+		StartTime: aws.Time(end.Add(time.Duration(-RangeSeconds) * time.Second)),
+
+		Period:     aws.Int64(int64(PeriodSeconds)),
+		MetricName: aws.String(metric.Name),
+		Namespace:  aws.String("AWS/RDS"),
+		Dimensions: []*cloudwatch.Dimension{},
+		Statistics: aws.StringSlice([]string{"Average"}),
+		Unit:       nil,
+	}
+
+	params.Dimensions = append(params.Dimensions, &cloudwatch.Dimension{
+		Name:  aws.String("DBInstanceIdentifier"),
+		Value: aws.String(instance),
+	})
+
+	// Call CloudWatch to gather the datapoints
+	resp, err := svc.GetMetricStatistics(params)
+	collector.TotalRequests.Inc()
+
+	if err != nil {
+		collector.ErroneousRequests.Inc()
+		return err
+	}
+
+	// There's nothing in there, don't publish the metric
+	if len(resp.Datapoints) == 0 {
+		return nil
+	}
+
+	// Pick the latest datapoint
+	dp := getLatestDatapoint(resp.Datapoints)
+	ch <- prometheus.MustNewConstMetric(metric.Desc, prometheus.GaugeValue, aws.Float64Value(dp.Average), labels...)
+
+	return nil
 }

--- a/collector_test.go
+++ b/collector_test.go
@@ -1,14 +1,16 @@
 package main
 
-import "testing"
+import (
+	"testing"
 
-func TestNewCwCollectorWithoutSettings(t *testing.T) {
-	c, err := NewCwCollector("a", "b", "c")
-	if err == nil {
-		t.Fatalf("err shouldn't be nil, got: %s", err)
-	}
+	"github.com/Percona-Lab/rds_exporter/config"
+)
 
-	if c != nil {
-		t.Fatal("collector should be nil")
+func TestNew(t *testing.T) {
+	settings := &config.Settings{}
+	c := New(settings)
+
+	if c == nil {
+		t.Fatal("collector should not be nil")
 	}
 }

--- a/collector_test.go
+++ b/collector_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	"github.com/Percona-Lab/rds_exporter/config"
+	"github.com/percona/rds_exporter/config"
 )
 
 func TestNew(t *testing.T) {

--- a/config.yml
+++ b/config.yml
@@ -1,53 +1,7 @@
-tasks:
- - name: billing
-   default_region: us-east-1
-   metrics:
-    - aws_namespace: "AWS/Billing"
-      aws_dimensions: [Currency]
-      aws_dimensions_select:
-        Currency: [USD]
-      aws_metric_name: EstimatedCharges
-      aws_statistics: [Average]
-      range_seconds: 86400
-
- - name: ec2_cloudwatch
-   metrics:
-    - aws_namespace: "AWS/EC2"
-      aws_dimensions: [InstanceId]
-      aws_dimensions_select:
-        InstanceId: [$_target]
-      aws_metric_name: CPUUtilization
-      aws_statistics: [Average]
-
-    - aws_namespace: "AWS/EC2"
-      aws_dimensions: [InstanceId]
-      aws_dimensions_select:
-        InstanceId: [$_target]
-      aws_metric_name: NetworkOut
-      aws_statistics: [Average]
-
- - name: vpn_mon
-   metrics:
-    - aws_namespace: "AWS/VPN"
-      aws_dimensions: [VpnId]
-      aws_dimensions_select:
-        VpnId: [$_target]
-      aws_metric_name: TunnelState
-      aws_statistics: [Average]
-      range_seconds: 3600
-
-    - aws_namespace: "AWS/VPN"
-      aws_dimensions: [VpnId]
-      aws_dimensions_select:
-        VpnId: [$_target]
-      aws_metric_name: TunnelDataIn
-      aws_statistics: [Average]
-      range_seconds: 3600
-
-    - aws_namespace: "AWS/VPN"
-      aws_dimensions: [VpnId]
-      aws_dimensions_select:
-        VpnId: [$_target]
-      aws_metric_name: TunnelDataOut
-      aws_statistics: [Average]
-      range_seconds: 3600
+instances:
+- instance: mysql56
+  region: us-east-1
+- instance: mysql57
+  region: eu-west-1
+- instance: aurora1
+  region: us-east-1

--- a/config/config.go
+++ b/config/config.go
@@ -1,77 +1,39 @@
 package config
 
 import (
-	"errors"
-	"fmt"
 	"io/ioutil"
-	"strings"
+	"sync"
 
 	"gopkg.in/yaml.v2"
 )
 
-type Metric struct {
-	Namespace string `yaml:"aws_namespace"`
-	Name      string `yaml:"aws_metric_name"`
-
-	Statistics            []string            `yaml:"aws_statistics"`
-	Dimensions            []string            `yaml:"aws_dimensions,omitempty"`
-	DimensionsSelect      map[string][]string `yaml:"aws_dimensions_select,omitempty"`
-	DimensionsSelectParam map[string][]string `yaml:"aws_dimensions_select_param,omitempty"`
-
-	RangeSeconds  int `yaml:"range_seconds,omitempty"`
-	PeriodSeconds int `yaml:"period_seconds,omitempty"`
-	DelaySeconds  int `yaml:"delay_seconds,omitempty"`
+type Instance struct {
+	Instance string `yaml:"instance"`
+	Region   string `yaml:"region"`
 }
 
-type Task struct {
-	Name          string   `yaml:"name"`
-	DefaultRegion string   `yaml:"default_region,omitempty"`
-	Metrics       []Metric `yaml:"metrics"`
+type Config struct {
+	Instances []Instance `yaml:"instances"`
 }
 
 type Settings struct {
-	AutoReload  bool   `yaml:"auto_reload,omitempty"`
-	ReloadDelay int    `yaml:"auto_reload_delay,omitempty"`
-	Tasks       []Task `yaml:"tasks"`
+	config Config
+	sync.RWMutex
 }
 
-func (s *Settings) GetTask(name string) (*Task, error) {
-	for i := range s.Tasks {
-		if strings.Compare(s.Tasks[i].Name, name) == 0 {
-			return &s.Tasks[i], nil
-		}
-	}
-
-	return nil, errors.New(fmt.Sprintf("can't find task '%s' in configuration", name))
-}
-
-func Load(filename string) (*Settings, error) {
+func (s *Settings) Load(filename string) error {
 	content, err := ioutil.ReadFile(filename)
 	if err != nil {
-		return nil, err
-	}
-
-	cfg := &Settings{}
-	err = yaml.Unmarshal(content, cfg)
-	if err != nil {
-		return nil, err
-	}
-	return cfg, nil
-}
-
-func (m *Metric) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	type plain Metric
-
-	// These are the default values for a basic metric config
-	rawMetric := plain{
-		PeriodSeconds: 60,
-		RangeSeconds:  600,
-		DelaySeconds:  600,
-	}
-	if err := unmarshal(&rawMetric); err != nil {
 		return err
 	}
 
-	*m = Metric(rawMetric)
-	return nil
+	s.Lock()
+	defer s.Unlock()
+	return yaml.Unmarshal(content, &s.config)
+}
+
+func (s *Settings) Config() Config {
+	s.RLock()
+	defer s.RUnlock()
+	return s.config
 }

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -17,37 +16,14 @@ import (
 var (
 	listenAddress = flag.String("web.listen-address", ":9042", "Address on which to expose metrics and web interface.")
 	metricsPath   = flag.String("web.telemetry-path", "/metrics", "Path under which to expose exporter's metrics.")
-	scrapePath    = flag.String("web.telemetry-scrape-path", "/scrape", "Path under which to expose CloudWatch metrics.")
 	configFile    = flag.String("config.file", "config.yml", "Path to configuration file.")
 
-	globalRegistry *prometheus.Registry
-	settings       *config.Settings
-	totalRequests  prometheus.Counter
-	configMutex    = &sync.Mutex{}
+	settings *config.Settings
 )
-
-func loadConfigFile() error {
-	var err error
-	var tmpSettings *config.Settings
-	configMutex.Lock()
-
-	// Initial loading of the configuration file
-	tmpSettings, err = config.Load(*configFile)
-	if err != nil {
-		return err
-	}
-
-	generateTemplates(tmpSettings)
-
-	settings = tmpSettings
-	configMutex.Unlock()
-
-	return nil
-}
 
 // handleReload handles a full reload of the configuration file and regenerates the collector templates.
 func handleReload(w http.ResponseWriter, req *http.Request) {
-	err := loadConfigFile()
+	err := settings.Load(*configFile)
 	if err != nil {
 		str := fmt.Sprintf("Can't read configuration file: %s", err.Error())
 		fmt.Fprintln(w, str)
@@ -56,70 +32,29 @@ func handleReload(w http.ResponseWriter, req *http.Request) {
 	fmt.Fprintln(w, "Reload complete")
 }
 
-// handleTarget handles scrape requests which make use of CloudWatch service
-func handleTarget(w http.ResponseWriter, req *http.Request) {
-	urlQuery := req.URL.Query()
-
-	target := urlQuery.Get("target")
-	task := urlQuery.Get("task")
-	region := urlQuery.Get("region")
-
-	// Check if we have all the required parameters in the URL
-	if task == "" {
-		fmt.Fprintln(w, "Error: Missing task parameter")
-		return
-	}
-
-	configMutex.Lock()
-	registry := prometheus.NewRegistry()
-	collector, err := NewCwCollector(target, task, region)
-	if err != nil {
-		// Can't create the collector, display error
-		fmt.Fprintf(w, "Error: %s\n", err.Error())
-		configMutex.Unlock()
-		return
-	}
-
-	registry.MustRegister(collector)
-	handler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{
-		DisableCompression: false,
-	})
-
-	// Serve the answer through the Collect method of the Collector
-	handler.ServeHTTP(w, req)
-	configMutex.Unlock()
-}
-
 func main() {
 	flag.Parse()
 
-	globalRegistry = prometheus.NewRegistry()
-
-	totalRequests = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "cloudwatch_requests_total",
-		Help: "API requests made to CloudWatch",
-	})
-
-	globalRegistry.MustRegister(totalRequests)
-
-	prometheus.DefaultGatherer = globalRegistry
-
-	err := loadConfigFile()
+	// Read configuration from file.
+	settings = &config.Settings{}
+	err := settings.Load(*configFile)
 	if err != nil {
 		fmt.Printf("Can't read configuration file: %s\n", err.Error())
 		os.Exit(-1)
 	}
 
-	fmt.Println("CloudWatch exporter started...")
+	// Create new Exporter with given settings.
+	exporter := New(settings)
+	prometheus.MustRegister(exporter)
 
 	// Expose the exporter's own metrics on /metrics
 	http.Handle(*metricsPath, promhttp.Handler())
 
-	// Expose CloudWatch through this endpoint
-	http.HandleFunc(*scrapePath, handleTarget)
-
 	// Allows manual reload of the configuration
 	http.HandleFunc("/reload", handleReload)
+
+	// Inform user we are ready.
+	fmt.Println("RDS exporter started...")
 
 	// Start serving for clients
 	log.Fatal(http.ListenAndServe(*listenAddress, nil))


### PR DESCRIPTION
>    Always get all RDS metrics.
>    Keep list of RDS metrics in code, not in configuration file.
>    Remove "name" from the configuration.
>    Remove "aws_namespace" from the configuration, always use "AWS/RDS".
>    Remove "aws_dimensions" from the configuration, always use "DBInstanceIdentifier".
>    Remove "aws_statistics" from the configuration, always use "Average".
>    Add a list of a region plus database instance name. It will be generated by pmm-managed.
