### PR TITLE
Added flag to disable enhanced metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ func main() {
 	}
 
 	log.Infof("Basic metrics   : http://%s%s", *listenAddressF, *basicMetricsPathF)
-	if *disableEnhancedMetrics ==false {
+	if *disableEnhancedMetrics == false {
 		log.Infof("Enhanced metrics: http://%s%s", *listenAddressF, *enhancedMetricsPathF)
 	}
 	log.Fatal(http.ListenAndServe(*listenAddressF, nil))

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ func main() {
 	}
 
 	// enhanced metrics
-	if *disableEnhancedMetrics == false {
+	if !*disableEnhancedMetrics {
 		registry := prometheus.NewRegistry()
 		registry.MustRegister(enhanced.NewCollector(sess))
 		http.Handle(*enhancedMetricsPathF, promhttp.HandlerFor(registry, promhttp.HandlerOpts{
@@ -64,7 +64,7 @@ func main() {
 	}
 
 	log.Infof("Basic metrics   : http://%s%s", *listenAddressF, *basicMetricsPathF)
-	if *disableEnhancedMetrics == false {
+	if !*disableEnhancedMetrics {
 		log.Infof("Enhanced metrics: http://%s%s", *listenAddressF, *enhancedMetricsPathF)
 	}
 	log.Fatal(http.ListenAndServe(*listenAddressF, nil))

--- a/main.go
+++ b/main.go
@@ -18,11 +18,12 @@ import (
 
 //nolint:lll
 var (
-	listenAddressF       = kingpin.Flag("web.listen-address", "Address on which to expose metrics and web interface.").Default(":9042").String()
-	basicMetricsPathF    = kingpin.Flag("web.basic-telemetry-path", "Path under which to expose exporter's basic metrics.").Default("/basic").String()
-	enhancedMetricsPathF = kingpin.Flag("web.enhanced-telemetry-path", "Path under which to expose exporter's enhanced metrics.").Default("/enhanced").String()
-	configFileF          = kingpin.Flag("config.file", "Path to configuration file.").Default("config.yml").String()
-	logTraceF            = kingpin.Flag("log.trace", "Enable verbose tracing of AWS requests (will log credentials).").Default("false").Bool()
+	listenAddressF         = kingpin.Flag("web.listen-address", "Address on which to expose metrics and web interface.").Default(":9042").String()
+	basicMetricsPathF      = kingpin.Flag("web.basic-telemetry-path", "Path under which to expose exporter's basic metrics.").Default("/basic").String()
+	enhancedMetricsPathF   = kingpin.Flag("web.enhanced-telemetry-path", "Path under which to expose exporter's enhanced metrics.").Default("/enhanced").String()
+	configFileF            = kingpin.Flag("config.file", "Path to configuration file.").Default("config.yml").String()
+	logTraceF              = kingpin.Flag("log.trace", "Enable verbose tracing of AWS requests (will log credentials).").Default("false").Bool()
+	disableEnhancedMetrics = kingpin.Flag("disable-enhanced-metrics", "Disable collection of enhanced metrics").Default("false").Bool()
 )
 
 func main() {
@@ -53,7 +54,7 @@ func main() {
 	}
 
 	// enhanced metrics
-	{
+	if *disableEnhancedMetrics ==false {
 		registry := prometheus.NewRegistry()
 		registry.MustRegister(enhanced.NewCollector(sess))
 		http.Handle(*enhancedMetricsPathF, promhttp.HandlerFor(registry, promhttp.HandlerOpts{
@@ -63,6 +64,8 @@ func main() {
 	}
 
 	log.Infof("Basic metrics   : http://%s%s", *listenAddressF, *basicMetricsPathF)
-	log.Infof("Enhanced metrics: http://%s%s", *listenAddressF, *enhancedMetricsPathF)
+	if *disableEnhancedMetrics ==false {
+		log.Infof("Enhanced metrics: http://%s%s", *listenAddressF, *enhancedMetricsPathF)
+	}
 	log.Fatal(http.ListenAndServe(*listenAddressF, nil))
 }

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ func main() {
 	}
 
 	// enhanced metrics
-	if *disableEnhancedMetrics ==false {
+	if *disableEnhancedMetrics == false {
 		registry := prometheus.NewRegistry()
 		registry.MustRegister(enhanced.NewCollector(sess))
 		http.Handle(*enhancedMetricsPathF, promhttp.HandlerFor(registry, promhttp.HandlerOpts{


### PR DESCRIPTION
Added flag disable-enhanced-metrics to prevent exporter from failing to start when enhanced metrics are not enabled on RDS instance.