### PR TITLE
node_disk_*: Keep a cumulative count of bytes read and written

### DIFF
--- a/enhanced/scraper.go
+++ b/enhanced/scraper.go
@@ -79,9 +79,9 @@ func (s *scraper) scrape(ctx context.Context) (map[string][]prometheus.Metric, m
 			l = l.With("IngestionTime", aws.MillisecondsTimeValue(event.IngestionTime).UTC())
 
 			var instance *sessions.Instance
-			for _, i := range s.instances {
-				if i.ResourceID == *event.LogStreamName {
-					instance = &i
+			for i := range s.instances {
+				if s.instances[i].ResourceID == *event.LogStreamName {
+					instance = &s.instances[i]
 					break
 				}
 			}
@@ -89,6 +89,10 @@ func (s *scraper) scrape(ctx context.Context) (map[string][]prometheus.Metric, m
 				l.Errorf("Failed to find instance.")
 				continue
 			}
+			if *event.Timestamp <= instance.LastEventTimestamp {
+				continue
+			}
+			instance.LastEventTimestamp = *event.Timestamp
 			l = l.With("region", instance.Region).With("instance", instance.Instance)
 
 			// l.Debugf("Message:\n%s", *event.Message)

--- a/sessions/sessions.go
+++ b/sessions/sessions.go
@@ -23,6 +23,7 @@ type Instance struct {
 	ResourceID                 string
 	Labels                     map[string]string
 	EnhancedMonitoringInterval time.Duration
+	LastEventTimestamp         int64
 }
 
 func (i Instance) String() string {


### PR DESCRIPTION
The node exporter maintains this as a counter of the total bytes read and written since system boot. RDS enhanced metrics do not give us this information, instead presenting the number of bytes read and written in each monitoring interval.

This means that the node exporter metrics we produce here were previously incorrect. Instead of directly exposing the information provided by the RDS metrics, maintain a counter to which we add the additional bytes read/written on each scrape.

Also, ensure that we only process each event once, as duplicate processing now means that cumulative statistics are incorrect.


### Feedback wanted

This change currently does not honour per-instance labels. This is because a `CounterVec` does not provide a way to have different labels per `Counter`.

I'm not sure what the best way is to solve this. We could calculate the union set of labels on all instances and add those labels to the `CounterVec`. Alternatively, if there is a good way to synthesise a new metric with the value of an existing metric, we could use the `CounterVec` to track the cumulative values and then create new metrics with added labels for export.

A third option is that there might be a better way to implement this change altogether.

I'm interested in some feedback on what kind of solution would be accepted before I put more work into this.