### PR TITLE
Add proxy configuration to the transport

### DIFF
--- a/client/transport.go
+++ b/client/transport.go
@@ -22,6 +22,7 @@ func newTransport() *transport {
 		t: &http.Transport{
 			MaxIdleConnsPerHost: 5,
 			IdleConnTimeout:     2 * time.Minute,
+			Proxy: http.ProxyFromEnvironment,
 		},
 		l: log.With("component", "transport"),
 


### PR DESCRIPTION
# What
If you run the exporter behind a proxy using `HTTPS_PROXY`, the transport won't pick the environment variable. I think because it's not the default Transport.

Here I am merely adding the configuration again, so it should be working as it is if you don't use any proxy and pick up the proxy if you are using it. Which we do in our case.