### PR TITLE
Add ACUUtilization metric

### DIFF
--- a/basic/metrics.go
+++ b/basic/metrics.go
@@ -251,4 +251,9 @@ var Metrics = []Metric{
 		prometheusName: "aws_rds_replica_lag",
 		prometheusHelp: "The amount of time a read replica DB instance lags behind the source DB instance. Unit: Seconds",
 	},
+	{
+		cwName:         "ACUUtilization",
+		prometheusName: "aws_rds_acu_utilization",
+		prometheusHelp: "This value is calculated as the value of the ServerlessDatabaseCapacity metric divided by the maximum ACU value of the DB cluster. Unit: Percent",
+	},
 }


### PR DESCRIPTION
This pull request aims to add the `ACUUtilization` metric to the code. This metric is new in Aurora Serverless v2 and is calculated as the value of the `ServerlessDatabaseCapacity` metric divided by the maximum ACU value of the instance.

Based on AWS [documentation](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.setting-capacity.html), the `ACUUtilization` metric can help better understand how the instance is being utilized and make decisions about scalability. By adding this metric to the code, users will be able to collect and analyze the `ACUUtilization` metric, allowing them to monitor and optimize the performance of their instance.

I believe that adding this metric will be a valuable feature for users and will help ensure ideal scalability and performance of the instance.

Thank you :smile: