### PR TITLE
TI-237 - Register rds_exporter to Backstage

### DIFF
--- a/.backstage/rds_exporter-component.yaml
+++ b/.backstage/rds_exporter-component.yaml
@@ -1,0 +1,18 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: rds_exporter-component
+  title: Prometheus AWS RDS Exporter
+  description: AWS RDS exporter for Prometheus. Public fork!
+  tags:
+    - go
+    - prometheus
+  links:
+    - url: https://github.com/ozean12/rds_exporter
+      title: Prometheus AWS RDS Exporter GitHub Repo
+      icon: github
+spec:
+  type: service
+  lifecycle: production
+  owner: infrastructure
+  system: observability-system


### PR DESCRIPTION
As the title says. This should make this repo available in our catalog at: https://backstage.ozean12.com/