### PR TITLE
Enable IRSA Mode for Kubernetes Deployments

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,7 @@ type Instance struct {
 	DisableBasicMetrics    bool              `yaml:"disable_basic_metrics"`
 	DisableEnhancedMetrics bool              `yaml:"disable_enhanced_metrics"`
 	Labels                 map[string]string `yaml:"labels"` // may be empty
+	IRSAEnabled            bool              `yaml:"irsa_enabled"`
 
 	// TODO Type InstanceType `yaml:"type"` // may be empty for old pmm-managed
 }


### PR DESCRIPTION
This PR adds support for IAM Roles for Service Accounts (IRSA) in the Percona RDS Exporter, allowing it to run in Kubernetes environments with improved security and reduced management overhead.

Context


IRSA is a feature in AWS EKS that allows Kubernetes pods to assume IAM roles directly using service accounts, eliminating the need to manage and store static credentials (e.g., access key/secret key pairs) within the pods. By enabling IRSA, Kubernetes workloads can leverage temporary security credentials obtained directly from the service account role, simplifying credential management and improving security posture. Previously, an aws secret was required by the exporter to assume the role arn and the exporter would fail is this was missing.


Changes

* If IRSA is enabled (irsa_enabled: true in the config), the exporter will utilize the default credential provider chain of the AWS SDK.
* The AWS SDK will automatically use the credentials mounted by IRSA in the pod, bypassing the need for explicit credential handling.
* In scenarios where IRSA is not enabled, the exporter retains its existing behavior of using a specified IAM role with access key/secret key, ensuring backward compatibility.
